### PR TITLE
Fixed UnicodeDecodeError

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,10 @@
 from setuptools import find_packages
 from setuptools import setup
 
-with open('README.md') as f:
+with open('README.md', encoding='utf-8') as f:
   readme = f.read()
 
-with open('LICENSE') as f:
+with open('LICENSE', encoding='utf-8') as f:
   lic = f.read()
 
 setup(


### PR DESCRIPTION
Environment: Windows 8.1
Python: 3.5.4

pip3 installation failed due to unicode decode issue.

Collecting tangent
  Using cached tangent-0.1.0.tar.gz
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "C:\Users\XXX\AppData\Local\Temp\pip-build-ivujnmhz\tangent\setup.py", line 5, in <module>
        readme = f.read()
      File "c:\python35\lib\encodings\cp1252.py", line 23, in decode
        return codecs.charmap_decode(input,self.errors,decoding_table)[0]
    UnicodeDecodeError: 'charmap' codec can't decode byte 0x9d in position 6304: character maps to <undefined>

    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in C:\Users\XXX\AppData\Local\Temp\pip-build-ivujnmhz\tangent\