### PR TITLE
Add parametrized tests for unary functions of a square matrix

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -103,4 +103,8 @@ def pytest_generate_tests(metafunc):
   if 'x' in metafunc.fixturenames:
     metafunc.parametrize('x', vectors)
 
+  matrices = [np.random.randn(i) for i in (((3, 3),) if short else ((1, 1), (5, 5)))]
+  if 'm' in metafunc.fixturenames:
+    metafunc.parametrize('m', matrices)
+
   tfe_utils.register_parametrizations(metafunc, short)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -103,8 +103,8 @@ def pytest_generate_tests(metafunc):
   if 'x' in metafunc.fixturenames:
     metafunc.parametrize('x', vectors)
 
-  matrices = [np.random.randn(i) for i in (((3, 3),) if short else ((1, 1), (5, 5)))]
-  if 'm' in metafunc.fixturenames:
-    metafunc.parametrize('m', matrices)
+  square_matrices = [np.random.randn(i) for i in (((3, 3),) if short else ((1, 1), (5, 5)))]
+  if 'sqm' in metafunc.fixturenames:
+    metafunc.parametrize('sqm', square_matrices)
 
   tfe_utils.register_parametrizations(metafunc, short)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -103,7 +103,7 @@ def pytest_generate_tests(metafunc):
   if 'x' in metafunc.fixturenames:
     metafunc.parametrize('x', vectors)
 
-  square_matrices = [np.random.randn(i) for i in (((3, 3),) if short else ((1, 1), (5, 5)))]
+  square_matrices = [np.random.randn(*i) for i in (((3, 3),) if short else ((1, 1), (5, 5)))]
   if 'sqm' in metafunc.fixturenames:
     metafunc.parametrize('sqm', square_matrices)
 

--- a/tests/test_reverse_mode.py
+++ b/tests/test_reverse_mode.py
@@ -121,6 +121,11 @@ def test_grad_vector(func, motion, optimized, preserve_result, x):
   utils.test_reverse_array(func, motion, optimized, preserve_result, x)
 
 
+def test_grad_square_matrix(func, motion, optimized, preserve_result, sqm):
+  """Test gradients of square matrix functions."""
+  utils.test_reverse_array(func, motion, optimized, preserve_result, sqm)
+
+
 def test_grad_binary_int(func, motion, optimized, preserve_result, a, n):
   """Test gradients of functions with scalar and integer input."""
   utils.test_reverse_array(func, motion, optimized, preserve_result, a, n)


### PR DESCRIPTION
Functions defined as `def function_name(sqm)` in tests/functions.py can now be used to test adjoints of functions of square matrices.