### PR TITLE
Pin gast to <0.3.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ autograd>=1.2
 astor>=0.6
 enum34
 future
-gast
+gast<0.3.0
 nose
 numpy
 six


### PR DESCRIPTION
Workaround for #97 - gast < 0.3.0 has the old-style API needed by LITERALS in tangent.grammar (`gast.Num`, `gast.Str`, etc.).