### PR TITLE
docs: fix simple typo, subtituted -> substituted

### DIFF
--- a/tangent/naming.py
+++ b/tangent/naming.py
@@ -95,7 +95,7 @@ class Namer(object):
   """Generate human-readable names for AST nodes.
 
   Given an AST node, this class tries to produce a sensible variable name
-  that it could be subtituted with.
+  that it could be substituted with.
 
   In principle, it will try to construct sensible names from the operands and
   operator e.g. `x + y` becomes `x_plus_y`. However, the length of these


### PR DESCRIPTION
There is a small typo in tangent/naming.py.

Should read `substituted` rather than `subtituted`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md